### PR TITLE
ci: install Expo web runtime deps before web export

### DIFF
--- a/.github/workflows/pr-ui-screenshot.yml
+++ b/.github/workflows/pr-ui-screenshot.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Expo web runtime dependencies
+        run: npm install --no-save react-native-web@~0.19.10 react-dom@18.2.0 @expo/metro-runtime@~3.2.3
+
       - name: Build web bundle
         run: npx expo export --platform web --output-dir dist
 


### PR DESCRIPTION
### Motivation
- Prevent the PR UI screenshot workflow from failing when running `npx expo export --platform web` due to missing Expo web runtime dependencies.

### Description
- Add a step to `.github/workflows/pr-ui-screenshot.yml` (immediately after `npm ci`) to run `npm install --no-save react-native-web@~0.19.10 react-dom@18.2.0 @expo/metro-runtime@~3.2.3` before executing `npx expo export --platform web --output-dir dist`.

### Testing
- Ran `git diff --check` which passed.
- Verified `git status --short` shows the intended workflow file change only.
- Attempted `npm install` locally which failed with a `403 Forbidden` for `@expo/metro-runtime` in this environment, but the workflow change is in place so CI on GitHub Actions will install the runtime deps before exporting the web bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69910a99feb08330bbf1093db7c0e374)